### PR TITLE
Fix dark mode toggle.

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -7,7 +7,7 @@
   let toggleDark = () => {
     let setDark = jtd.getTheme() !== 'dark';
     jtd.setTheme(setDark ? 'dark' : 'default');
-    localStorage.setItem('darkMode', setDark);
+    localStorage.setItem('darkMode', String(setDark));
   };
 
   window.addEventListener('DOMContentLoaded', () => {
@@ -19,7 +19,7 @@
     });
 
     /* Read local storage state. */
-    if (localStorage.getItem('darkMode')) {
+    if (localStorage.getItem('darkMode') === 'true') {
       toggleDark();
     }
   });


### PR DESCRIPTION
Currently, I think that once a user has turned dark mode on, turning dark mode off will not persist between refreshes of the site.

Recreation:
- Start with the default theme of the site.
- Turn dark mode on.
- Refresh and turn the dark mode off. The site will go back to light mode (until we refresh in the next step)
- Refresh. The page will be using dark mode even though we turned it off in the previous step.

Fix:
- `localStorage.getItem('darkMode')` returns a String, so as long as `getItem` returned any non-empty string (either `"true"` or `"false"`), then dark mode was getting turned on. So, we now compare with the String `"true"`.